### PR TITLE
Fix incorrect colorRelief default on/off setting

### DIFF
--- a/src/lib/Viewer.svelte
+++ b/src/lib/Viewer.svelte
@@ -165,10 +165,6 @@
     pseudocolor: {
       interval: 1,
       // opacity: 1, // See ColorRelief
-      // min_low: 1,
-      // low: 1,
-      // high: 2,
-      // max_high: 2
     },
     terrain: {
       exaggeration: 1,
@@ -297,7 +293,7 @@
     controls.hillshade.visibility = raster_dem_header ? true : false;
     controls.overlay.visibility = raster_overlay_header ? true : false;
     controls.terrain.enabled = raster_dem_header ? true : false;
-    colorRelief.opacity = raster_header ? 0.0 : 1.0;
+    colorRelief.colorReliefLayerVisibility = raster_header ? 'none' : 'visible';
     maxZoom = raster_metadata?.maxzoom ?? raster_dem_metadata?.maxzoom ?? raster_overlay_metadata?.maxzoom ?? undefined;
     const version = raster_metadata?.metadataVersion ?? raster_dem_metadata?.metadataVersion ?? raster_overlay_metadata?.metadataVersion;
     if (version === "0.4.0") {


### PR DESCRIPTION
Set visibilty, not opacity, when checking if raster layer exists